### PR TITLE
✏️ Fix typo in eslint plugin README.md

### DIFF
--- a/packages/eslint-plugin-use-selector-with/README.md
+++ b/packages/eslint-plugin-use-selector-with/README.md
@@ -66,7 +66,7 @@ Enforces using `useSelector` instead of `useSelectorWith` if there are no args t
 Examples of _failing_ code with this rule:
 
 ```ts
-const value = useSelectorWith(state, getValueFromState);
+const value = useSelectorWith(getValueFromState);
 ```
 
 Examples of _passing_ code with this rule:


### PR DESCRIPTION
Neat selector! Saw a tiny typo in the README and fixed it :)

Was hoping this would solve some selector issues I've been working through recently but this solves a slightly different issue.